### PR TITLE
Parallelize loading from S3 for better performance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,20 @@
 {
   "name": "near-lake-framework",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "near-lake-framework",
-      "version": "1.0.0",
+      "version": "1.0.1",
+      "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.32.0"
       },
       "devDependencies": {
         "@types/node": "^17.0.23",
-        "prettier": "2.6.2"
+        "prettier": "2.6.2",
+        "typescript": "^4.6.4"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -1237,6 +1239,19 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
+    "node_modules/typescript": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -2271,6 +2286,12 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "typescript": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "dev": true
     },
     "uuid": {
       "version": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,12 @@
   "version": "1.0.1",
   "description": "JS Library to connect to the NEAR Lake S3 and stream the data",
   "author": "NEAR Inc <hello@nearprotocol.com>",
-  "keywords": ["nearprotocol", "near-indexer", "near-lake", "framework"],
+  "keywords": [
+    "nearprotocol",
+    "near-indexer",
+    "near-lake",
+    "framework"
+  ],
   "license": "(MIT OR Apache-2.0)",
   "repository": {
     "type": "git",
@@ -20,6 +25,7 @@
   },
   "devDependencies": {
     "@types/node": "^17.0.23",
-    "prettier": "2.6.2"
+    "prettier": "2.6.2",
+    "typescript": "^4.6.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,10 @@
   "files": [
     "/dist"
   ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc -w"
+  },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.32.0"
   },

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "/dist"
   ],
   "scripts": {
+    "prepare": "npm run build",
     "build": "tsc",
     "dev": "tsc -w"
   },

--- a/src/s3fetchers.ts
+++ b/src/s3fetchers.ts
@@ -22,7 +22,7 @@ export async function listBlocks(
   client: S3Client,
   bucketName: string,
   startAfter: BlockHeight,
-  limit = 10
+  limit = 200
 ): Promise<BlockHeight[]> {
   const data = await client.send(
     new ListObjectsV2Command({

--- a/src/s3fetchers.ts
+++ b/src/s3fetchers.ts
@@ -21,12 +21,13 @@ import { normalizeBlockHeight, parseBody } from "./utils";
 export async function listBlocks(
   client: S3Client,
   bucketName: string,
-  startAfter: BlockHeight
+  startAfter: BlockHeight,
+  limit = 10
 ): Promise<BlockHeight[]> {
   const data = await client.send(
     new ListObjectsV2Command({
       Bucket: bucketName,
-      MaxKeys: 10,
+      MaxKeys: limit,
       Delimiter: "/",
       StartAfter: normalizeBlockHeight(startAfter),
       RequestPayer: "requester",

--- a/src/streamer.ts
+++ b/src/streamer.ts
@@ -20,7 +20,7 @@ export async function startStream(
         s3Client,
         config.s3BucketName,
         startFromBlockHeight,
-        config.batchSize
+        config.blocksPreloadPoolSize
       );
     } catch (err) {
       console.error("Failed to list blocks. Retrying.", err);

--- a/src/streamer.ts
+++ b/src/streamer.ts
@@ -31,12 +31,9 @@ export async function startStream(
       continue;
     }
 
-    for (let blockHeight of blockHeights) {
-      const streamerMessage = await fetchStreamerMessage(
-        s3Client,
-        config.s3BucketName,
-        blockHeight
-      );
+    const messages = await Promise.all(
+      blockHeights.map(blockHeight => fetchStreamerMessage(s3Client, config.s3BucketName, blockHeight)));
+    for (let streamerMessage of messages) {
       // check if we have `lastProcessedBlockHash` (might be not set only on start)
       // compare lastProcessedBlockHash` with `streamerMessage.block.header.prevHash` of the current
       // block (ensure we never skip blocks even if there is some incident on Lake Indexer side)

--- a/src/streamer.ts
+++ b/src/streamer.ts
@@ -19,7 +19,8 @@ export async function startStream(
       blockHeights = await listBlocks(
         s3Client,
         config.s3BucketName,
-        startFromBlockHeight
+        startFromBlockHeight,
+        config.batchSize
       );
     } catch (err) {
       console.error("Failed to list blocks. Retrying.", err);

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ export interface LakeConfig {
   s3BucketName: string;
   s3RegionName: string;
   startBlockHeight: number;
-  batchSize: number;
+  blocksPreloadPoolSize?: number;
 }
 
 export interface StreamerMessage {

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export interface LakeConfig {
   s3BucketName: string;
   s3RegionName: string;
   startBlockHeight: number;
+  batchSize: number;
 }
 
 export interface StreamerMessage {


### PR DESCRIPTION
Note that this is relatively naive method which unnecessarily waits for one batch to complete before starting another batch load.

However it still seems to improve performance significantly.

Results in improvement of from about 2 blocks/second to 12+ blocks/second on my machine.

When measured at Hetzner box I use:

- Batch size 1 ≈ 5 blocks/second
- Batch size 10 ≈ 36 blocks/second
- Batch size 20 ≈ 66 blocks/second
- Batch size 50 ≈ 145 blocks/second
- Batch size 100 ≈ 195 blocks/second
- Batch size 200 ≈ 234 blocks/second
