### PR TITLE
fix: Ensure `primitives` is installed when installing `framework`

### DIFF
--- a/.changeset/brave-goats-talk.md
+++ b/.changeset/brave-goats-talk.md
@@ -1,0 +1,5 @@
+---
+"@near-lake/framework": patch
+---
+
+Specify `@near-lake/primitives` via semver rather than local path to ensure that it is installed when pulling this package from the registry.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4522,7 +4522,7 @@
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.32.0",
-        "@near-lake/primitives": "file:../near-lake-primitives"
+        "@near-lake/primitives": "^0.1.0"
       }
     },
     "packages/near-lake-primitives": {
@@ -5891,7 +5891,7 @@
       "version": "file:packages/near-lake-framework",
       "requires": {
         "@aws-sdk/client-s3": "^3.32.0",
-        "@near-lake/primitives": "file:../near-lake-primitives"
+        "@near-lake/primitives": "^0.1.0"
       }
     },
     "@near-lake/nft-indexer": {

--- a/packages/near-lake-framework/package.json
+++ b/packages/near-lake-framework/package.json
@@ -27,6 +27,6 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.32.0",
-    "@near-lake/primitives": "file:../near-lake-primitives"
+    "@near-lake/primitives": "^0.1.0"
   }
 }


### PR DESCRIPTION
`@near-lake/framework` currently lists `@near-lake/primitives` as a `dependency` via a local path. When `@near-lake/framework` is pulled from the registry, NPM will not also install `@near-lake/primitives` as it is defined via local path.

This PR updates `@near-lake/framework` to specify `@near-lake/primitives` via semver, ensuring that it's installed when pulling `framework`. AFAIK this doesn't change the symlinking behaviour locally. When running `npm i` within this project, the local copy of `@near-lake/primitives` will still be used.
