### PR TITLE
fix: Ensure stream handlers are throttled in sequence

### DIFF
--- a/.changeset/rich-deers-retire.md
+++ b/.changeset/rich-deers-retire.md
@@ -1,0 +1,5 @@
+---
+"@near-lake/framework": patch
+---
+
+Ensure stream handlers are throttled and executed in sequence


### PR DESCRIPTION
The current implementation of `startStream` calls the stream handler when pushing to the "throttling" `queue`. This executes the `Promise` immediately and does not wait for it's result before executing the next. As the comment in `startStream` explains, this causes many many handlers to executed, not garuanteeing any sequence to execution, and probably being very resource intensive.

This PR defers the execution of stream handlers by wrapping the handler in another function before pushing it to the `queue`. Then when we read from the `queue`, the handler is called and `await`ed. This ensures that handlers are throttled, and executed in order.