### PR TITLE
fix: Ensure `borsh` is accessible within published package

### DIFF
--- a/.changeset/real-hounds-invite.md
+++ b/.changeset/real-hounds-invite.md
@@ -1,0 +1,5 @@
+---
+"@near-lake/primitives": minor
+---
+
+Ensure `borsh` export is accessible within published package

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "demo": "turbo run demo --filter=@near-lake/$npm_config_name",
     "test": "turbo run test",
     "docs:generate": "typedoc",
-    "release": "changeset publish"
+    "release": "changeset publish",
+    "changeset": "changeset add"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.4.6",

--- a/packages/near-lake-primitives/package.json
+++ b/packages/near-lake-primitives/package.json
@@ -7,7 +7,7 @@
   ],
   "author": "NEAR Inc <hello@nearprotocol.com>",
   "description": "Near Protocol primitive datatypes utilized by near-lake-framework",
-  "main": "dist/src/types/index.js",
+  "main": "dist/src/index.js",
   "files": [
     "/dist"
   ],


### PR DESCRIPTION
package.json `main` was pointing to a subfolder, which therefore ignored
the top level `borsh` export. This changes `main` to point to the root
dir, making `borsh` accessible, while also keeping the existing exports
unchanged.
